### PR TITLE
Return an empty list when there is no thumbnails

### DIFF
--- a/sphinx/tutorials/image.rst
+++ b/sphinx/tutorials/image.rst
@@ -89,11 +89,11 @@ the ``as_mutable`` method is used to make a type mutable.
 
     from sqlalchemy import Column, Integer
 
-    from sqlalchemy_media import Image, ImageAnalizer, ImageValidator, ImageProcessor
+    from sqlalchemy_media import Image, ImageAnalyzer, ImageValidator, ImageProcessor
 
     class ProfileImage(Image):
         __pre_processors__ = [
-            ImageAnalizer(),
+            ImageAnalyzer(),
             ImageValidator(
                 minimum=(80, 80),
                 maximum=(800, 600),

--- a/sqlalchemy_media/imaginglibs.py
+++ b/sqlalchemy_media/imaginglibs.py
@@ -11,6 +11,6 @@ def get_image_factory():
     except OptionalPackageRequirementError:
         # Re-raising the exception again, because currently there is only one image library
         # available, but after implementing the #97 the exception should be passed silently.
-        # And should raised if the neghter PILLOW and or PIL is not installed.
+        # And should raised if the neighter PILLOW and or PIL is not installed.
         raise
 


### PR DESCRIPTION
This change to `attachments.py` removes the need to check if the `thumbnails` key exists in the `image` dictionary and returns and empty list when calling the `thumbnails` prop of the image object.

It also removes an unused import to `ensure_wand`.